### PR TITLE
feat: add A2A registry catalog module for syncing agents from a2aregi…

### DIFF
--- a/.dapr/components/cron-a2a-registry-sync.yaml
+++ b/.dapr/components/cron-a2a-registry-sync.yaml
@@ -1,0 +1,18 @@
+# Dapr cron binding — triggers A2A registry catalog sync on schedule.
+# The endpoint POST /a2a-registry/cron-sync is handled in budconnect/a2a_registry/routes.py.
+# Schedule uses standard cron syntax: @every duration
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: cron-a2a-registry-sync
+  namespace: development
+spec:
+  type: bindings.cron
+  version: v1
+  metadata:
+    - name: schedule
+      value: "@every 12h"      # Every 24 hours from app start
+    - name: direction
+      value: "input"
+    - name: route
+      value: "/a2a-registry/cron-sync"

--- a/alembic/versions/h4i5j6k7l8m9_add_a2a_registry_agent.py
+++ b/alembic/versions/h4i5j6k7l8m9_add_a2a_registry_agent.py
@@ -1,0 +1,63 @@
+"""Add a2a_registry_agent table.
+
+Revision ID: h4i5j6k7l8m9
+Revises: g1h2i3j4k5l6
+Create Date: 2026-03-31 00:00:00.000000
+
+This migration creates the a2a_registry_agent table for storing
+A2A agents fetched from a2aregistry.org.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from alembic import op
+
+revision: str = "h4i5j6k7l8m9"
+down_revision: Union[str, None] = "g1h2i3j4k5l6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create a2a_registry_agent table."""
+    op.create_table(
+        "a2a_registry_agent",
+        sa.Column("id", sa.UUID(), nullable=False, default=sa.text("gen_random_uuid()")),
+        sa.Column("registry_id", sa.String(), nullable=True),
+        sa.Column("base_url", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("author", sa.String(), nullable=True),
+        sa.Column("version", sa.String(), nullable=True),
+        sa.Column("protocol_version", sa.String(), nullable=True),
+        sa.Column("provider", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("skills", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("capabilities", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("security_schemes", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("security", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("icon_url", sa.String(), nullable=True),
+        sa.Column("default_input_modes", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("default_output_modes", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("documentation_url", sa.String(), nullable=True),
+        sa.Column("conformance", sa.Boolean(), nullable=True, server_default=sa.text("true")),
+        sa.Column("is_healthy", sa.Boolean(), nullable=True),
+        sa.Column("uptime_percentage", sa.Float(), nullable=True),
+        sa.Column("avg_response_time_ms", sa.Integer(), nullable=True),
+        sa.Column("last_health_check", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("supports_authenticated_extended_card", sa.Boolean(), nullable=True),
+        sa.Column("maintainer_notes", sa.Text(), nullable=True),
+        sa.Column("homepage", sa.String(), nullable=True),
+        sa.Column("repository", sa.String(), nullable=True),
+        sa.Column("license", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("modified_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("base_url"),
+    )
+
+
+def downgrade() -> None:
+    """Drop a2a_registry_agent table."""
+    op.drop_table("a2a_registry_agent")

--- a/budconnect/a2a_registry/__init__.py
+++ b/budconnect/a2a_registry/__init__.py
@@ -1,0 +1,17 @@
+#  -----------------------------------------------------------------------------
+#  Copyright (c) 2024 Bud Ecosystem Inc.
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  -----------------------------------------------------------------------------
+
+"""A2A Registry module — fetches and stores A2A agents from a2aregistry.org."""

--- a/budconnect/a2a_registry/crud.py
+++ b/budconnect/a2a_registry/crud.py
@@ -1,0 +1,156 @@
+#  -----------------------------------------------------------------------------
+#  Copyright (c) 2024 Bud Ecosystem Inc.
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  -----------------------------------------------------------------------------
+
+"""CRUD operations for A2A registry agents."""
+
+from typing import Any, Dict, List, Optional, Set, Tuple
+from uuid import UUID
+
+from budmicroframe.commons import logging
+from budmicroframe.shared.psql_service import CRUDMixin
+from sqlalchemy import delete, func
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from .models import A2ARegistryAgent
+
+logger = logging.get_logger(__name__)
+
+
+class A2ARegistryAgentCRUD(CRUDMixin[A2ARegistryAgent, None, None]):
+    """CRUD operations for A2A registry agents."""
+
+    __model__ = A2ARegistryAgent
+
+    def __init__(self) -> None:
+        """Initialize the A2ARegistryAgentCRUD class."""
+        super().__init__(self.__model__)
+
+    def upsert_by_base_url(
+        self,
+        data: Dict[str, Any],
+        session: Optional[Session] = None,
+    ) -> UUID:
+        """Insert or update an agent by base_url.
+
+        Args:
+            data: Agent data dict matching A2ARegistryAgentCreate fields.
+            session: Existing SQLAlchemy session. If None, creates new one.
+
+        Returns:
+            UUID: The ID of the created or updated record.
+        """
+        _session = session or self.get_session()
+        try:
+            stmt = insert(self.__model__.__table__).values(data)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["base_url"],
+                set_={k: v for k, v in data.items() if k != "id"},
+            )
+            stmt = stmt.returning(self.__model__.id)
+            result = _session.execute(stmt)
+            _session.commit()
+
+            row = result.first()
+            if row:
+                return UUID(str(row[0]))
+
+            raise ValueError("No result returned from upsert operation")
+        except SQLAlchemyError as e:
+            _session.rollback()
+            logger.exception("Failed to upsert A2A agent: %s", e)
+            raise ValueError("Failed to upsert A2A agent") from e
+        finally:
+            self.cleanup_session(_session if session is None else None)
+
+    def fetch_many(
+        self,
+        page: int = 1,
+        page_size: int = 50,
+        session: Optional[Session] = None,
+    ) -> Tuple[int, List[A2ARegistryAgent]]:
+        """Fetch paginated A2A registry agents.
+
+        Args:
+            page: Page number (1-indexed).
+            page_size: Number of results per page.
+            session: Existing SQLAlchemy session.
+
+        Returns:
+            Tuple of (total_count, list_of_agents).
+        """
+        _session = session or self.get_session()
+        try:
+            query = _session.query(self.__model__)
+
+            total = query.count()
+            offset = (page - 1) * page_size
+            agents = query.order_by(self.__model__.name).offset(offset).limit(page_size).all()
+
+            return total, agents
+        finally:
+            self.cleanup_session(_session if session is None else None)
+
+    def delete_absent(
+        self,
+        current_base_urls: Set[str],
+        session: Optional[Session] = None,
+    ) -> int:
+        """Hard-delete agents whose base_url is NOT in the given set.
+
+        Args:
+            current_base_urls: Set of base_urls from the latest registry fetch.
+            session: Existing SQLAlchemy session.
+
+        Returns:
+            Number of deleted rows.
+        """
+        if not current_base_urls:
+            return 0
+
+        _session = session or self.get_session()
+        try:
+            stmt = delete(self.__model__).where(
+                self.__model__.base_url.notin_(current_base_urls)
+            )
+            result = _session.execute(stmt)
+            _session.commit()
+            deleted = result.rowcount
+            if deleted > 0:
+                logger.info("Deleted %d absent A2A registry agents", deleted)
+            return deleted
+        except SQLAlchemyError as e:
+            _session.rollback()
+            logger.exception("Failed to delete absent A2A agents: %s", e)
+            return 0
+        finally:
+            self.cleanup_session(_session if session is None else None)
+
+    def count(self, session: Optional[Session] = None) -> int:
+        """Count total active A2A registry agents.
+
+        Args:
+            session: Existing SQLAlchemy session.
+
+        Returns:
+            Total number of agents.
+        """
+        _session = session or self.get_session()
+        try:
+            return _session.query(func.count(self.__model__.id)).scalar() or 0
+        finally:
+            self.cleanup_session(_session if session is None else None)

--- a/budconnect/a2a_registry/crud.py
+++ b/budconnect/a2a_registry/crud.py
@@ -64,9 +64,10 @@ class A2ARegistryAgentCRUD(CRUDMixin[A2ARegistryAgent, None, None]):
             )
             stmt = stmt.returning(self.__model__.id)
             result = _session.execute(stmt)
-            _session.commit()
-
             row = result.first()
+            if session is None:
+                _session.commit()
+
             if row:
                 return UUID(str(row[0]))
 
@@ -127,8 +128,9 @@ class A2ARegistryAgentCRUD(CRUDMixin[A2ARegistryAgent, None, None]):
         try:
             stmt = delete(self.__model__).where(self.__model__.base_url.notin_(current_base_urls))
             result = _session.execute(stmt)
-            _session.commit()
             deleted = result.rowcount
+            if session is None:
+                _session.commit()
             if deleted > 0:
                 logger.info("Deleted %d absent A2A registry agents", deleted)
             return deleted

--- a/budconnect/a2a_registry/crud.py
+++ b/budconnect/a2a_registry/crud.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import Session
 
 from .models import A2ARegistryAgent
 
+
 logger = logging.get_logger(__name__)
 
 
@@ -124,9 +125,7 @@ class A2ARegistryAgentCRUD(CRUDMixin[A2ARegistryAgent, None, None]):
 
         _session = session or self.get_session()
         try:
-            stmt = delete(self.__model__).where(
-                self.__model__.base_url.notin_(current_base_urls)
-            )
+            stmt = delete(self.__model__).where(self.__model__.base_url.notin_(current_base_urls))
             result = _session.execute(stmt)
             _session.commit()
             deleted = result.rowcount

--- a/budconnect/a2a_registry/models.py
+++ b/budconnect/a2a_registry/models.py
@@ -1,0 +1,94 @@
+#  -----------------------------------------------------------------------------
+#  Copyright (c) 2024 Bud Ecosystem Inc.
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  -----------------------------------------------------------------------------
+
+"""SQLAlchemy model for A2A registry agents fetched from a2aregistry.org."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from budmicroframe.shared.psql_service import PSQLBase, TimestampMixin
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class A2ARegistryAgent(PSQLBase, TimestampMixin):
+    """A2A agent fetched from the public a2aregistry.org catalog.
+
+    Stores standard, healthy A2A agents for discovery. Synced periodically
+    from a2aregistry.org and served to budapp via paginated API.
+
+    Attributes:
+        id: Internal UUID primary key.
+        registry_id: Original UUID from the a2aregistry.org API.
+        base_url: Agent's base URL — unique dedup key. The well-known agent card
+            URL is derived at runtime as {base_url}/.well-known/agent.json.
+        name: Human-readable agent name.
+        description: Agent description/purpose.
+        author: Author or organization name from registry.
+        version: Agent version string.
+        protocol_version: A2A protocol version (e.g., "0.3.0").
+        provider: Provider info as JSON object {organization, url}.
+        skills: Array of skill objects [{id, name, description, tags, ...}].
+        capabilities: Capability flags {streaming, pushNotifications, ...}.
+        security_schemes: SecuritySchemes object (currently {} for most agents).
+        security: Security requirements array (currently [] for most agents).
+        icon_url: Agent icon URL.
+        default_input_modes: Supported input MIME types.
+        default_output_modes: Supported output MIME types.
+        documentation_url: Link to agent documentation.
+        conformance: True if agent conforms to A2A standard protocol.
+        is_healthy: Health status from registry health checks.
+        uptime_percentage: Uptime percentage from registry monitoring.
+        avg_response_time_ms: Average response time in milliseconds.
+        last_health_check: Timestamp of last registry health check.
+        supports_authenticated_extended_card: Whether agent supports authenticated extended card.
+        maintainer_notes: Registry maintainer notes about the agent.
+        homepage: Agent homepage URL.
+        repository: Source code repository URL.
+        license: License type string.
+    """
+
+    __tablename__ = "a2a_registry_agent"
+
+    id: Mapped[str] = mapped_column(UUID, primary_key=True, default=uuid4, nullable=False)
+    registry_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    base_url: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    author: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    version: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    protocol_version: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    provider: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    skills: Mapped[Optional[List[Dict[str, Any]]]] = mapped_column(JSONB, nullable=True)
+    capabilities: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    security_schemes: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    security: Mapped[Optional[List[Dict[str, Any]]]] = mapped_column(JSONB, nullable=True)
+    icon_url: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    default_input_modes: Mapped[Optional[List[str]]] = mapped_column(JSONB, nullable=True)
+    default_output_modes: Mapped[Optional[List[str]]] = mapped_column(JSONB, nullable=True)
+    documentation_url: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    conformance: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True, default=True)
+    is_healthy: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    uptime_percentage: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    avg_response_time_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    last_health_check: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    supports_authenticated_extended_card: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    maintainer_notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    homepage: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    repository: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    license: Mapped[Optional[str]] = mapped_column(String, nullable=True)

--- a/budconnect/a2a_registry/routes.py
+++ b/budconnect/a2a_registry/routes.py
@@ -1,0 +1,95 @@
+#  -----------------------------------------------------------------------------
+#  Copyright (c) 2024 Bud Ecosystem Inc.
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  -----------------------------------------------------------------------------
+
+"""API routes for A2A registry agent catalog."""
+
+import asyncio
+import time
+
+from budmicroframe.commons import logging
+from budmicroframe.commons.exceptions import ClientException
+from budmicroframe.commons.schemas import ErrorResponse
+from fastapi import APIRouter, HTTPException, Query, status
+
+from .schemas import A2ARegistryAgentListResponse, A2ARegistrySyncResponse
+from .services import A2ARegistryService
+
+logger = logging.get_logger(__name__)
+
+a2a_registry_router = APIRouter(prefix="/a2a-registry", tags=["A2A Registry"])
+
+_a2a_registry_sync_lock = asyncio.Lock()
+
+
+@a2a_registry_router.get("/agents", response_model=A2ARegistryAgentListResponse)
+async def list_a2a_registry_agents(
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(50, ge=1, le=200, description="Number of items per page"),
+) -> A2ARegistryAgentListResponse:
+    """List A2A registry agents from local catalog.
+
+    Serves paginated agents synced from a2aregistry.org for consumption by budapp.
+
+    Args:
+        page: Page number (1-indexed).
+        page_size: Number of results per page.
+
+    Returns:
+        Paginated list of A2A registry agents.
+    """
+    try:
+        result = A2ARegistryService.get_all_agents(page=page, page_size=page_size)
+        return result
+    except ClientException as e:
+        logger.error(f"Client exception: {e}")
+        error_response = ErrorResponse(message=e.message, code=e.status_code)
+        return error_response.to_http_response()
+    except Exception as e:
+        logger.exception(f"Error fetching A2A registry agents: {e}")
+        error_response = ErrorResponse(
+            message="Error fetching A2A registry agents", code=status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
+        return error_response.to_http_response()
+
+
+@a2a_registry_router.post("/cron-sync", response_model=A2ARegistrySyncResponse)
+async def handle_a2a_registry_sync() -> A2ARegistrySyncResponse:
+    """Dapr cron binding endpoint — triggers periodic A2A registry catalog sync.
+
+    Protected by asyncio.Lock to prevent overlapping runs.
+    """
+    if _a2a_registry_sync_lock.locked():
+        logger.warning("A2A registry sync already in progress, skipping this trigger")
+        return A2ARegistrySyncResponse(status="skipped", duration_seconds=0.0)
+
+    async with _a2a_registry_sync_lock:
+        start_time = time.monotonic()
+        logger.info("Starting periodic A2A registry catalog sync...")
+        try:
+            summary = await A2ARegistryService.sync()
+            elapsed = time.monotonic() - start_time
+            logger.info("A2A registry sync completed successfully in %.1f seconds", elapsed)
+            return A2ARegistrySyncResponse(
+                status="success",
+                duration_seconds=round(elapsed, 1),
+                **summary,
+            )
+        except Exception as e:
+            elapsed = time.monotonic() - start_time
+            logger.error("A2A registry sync failed after %.1f seconds: %s", elapsed, e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
+            ) from e

--- a/budconnect/a2a_registry/routes.py
+++ b/budconnect/a2a_registry/routes.py
@@ -27,6 +27,7 @@ from fastapi import APIRouter, HTTPException, Query, status
 from .schemas import A2ARegistryAgentListResponse, A2ARegistrySyncResponse
 from .services import A2ARegistryService
 
+
 logger = logging.get_logger(__name__)
 
 a2a_registry_router = APIRouter(prefix="/a2a-registry", tags=["A2A Registry"])
@@ -90,6 +91,4 @@ async def handle_a2a_registry_sync() -> A2ARegistrySyncResponse:
         except Exception as e:
             elapsed = time.monotonic() - start_time
             logger.error("A2A registry sync failed after %.1f seconds: %s", elapsed, e)
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-            ) from e
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)) from e

--- a/budconnect/a2a_registry/schemas.py
+++ b/budconnect/a2a_registry/schemas.py
@@ -1,0 +1,108 @@
+#  -----------------------------------------------------------------------------
+#  Copyright (c) 2024 Bud Ecosystem Inc.
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  -----------------------------------------------------------------------------
+
+"""Pydantic schemas for A2A registry agents."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import UUID4, BaseModel, ConfigDict
+
+
+class A2ARegistryAgentCreate(BaseModel):
+    """Schema for creating/upserting an A2A registry agent from the registry API."""
+
+    registry_id: Optional[str] = None
+    base_url: str
+    name: str
+    description: Optional[str] = None
+    author: Optional[str] = None
+    version: Optional[str] = None
+    protocol_version: Optional[str] = None
+    provider: Optional[Dict[str, Any]] = None
+    skills: Optional[List[Dict[str, Any]]] = None
+    capabilities: Optional[Dict[str, Any]] = None
+    security_schemes: Optional[Dict[str, Any]] = None
+    security: Optional[List[Dict[str, Any]]] = None
+    icon_url: Optional[str] = None
+    default_input_modes: Optional[List[str]] = None
+    default_output_modes: Optional[List[str]] = None
+    documentation_url: Optional[str] = None
+    conformance: Optional[bool] = True
+    is_healthy: Optional[bool] = None
+    uptime_percentage: Optional[float] = None
+    avg_response_time_ms: Optional[int] = None
+    last_health_check: Optional[datetime] = None
+    supports_authenticated_extended_card: Optional[bool] = None
+    maintainer_notes: Optional[str] = None
+    homepage: Optional[str] = None
+    repository: Optional[str] = None
+    license: Optional[str] = None
+
+
+class A2ARegistryAgentResponse(BaseModel):
+    """Schema for A2A registry agent API responses."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID4
+    registry_id: Optional[str] = None
+    base_url: str
+    name: str
+    description: Optional[str] = None
+    author: Optional[str] = None
+    version: Optional[str] = None
+    protocol_version: Optional[str] = None
+    provider: Optional[Dict[str, Any]] = None
+    skills: Optional[List[Dict[str, Any]]] = None
+    capabilities: Optional[Dict[str, Any]] = None
+    security_schemes: Optional[Dict[str, Any]] = None
+    security: Optional[List[Dict[str, Any]]] = None
+    icon_url: Optional[str] = None
+    default_input_modes: Optional[List[str]] = None
+    default_output_modes: Optional[List[str]] = None
+    documentation_url: Optional[str] = None
+    conformance: Optional[bool] = None
+    is_healthy: Optional[bool] = None
+    uptime_percentage: Optional[float] = None
+    avg_response_time_ms: Optional[int] = None
+    last_health_check: Optional[datetime] = None
+    supports_authenticated_extended_card: Optional[bool] = None
+    maintainer_notes: Optional[str] = None
+    homepage: Optional[str] = None
+    repository: Optional[str] = None
+    license: Optional[str] = None
+    created_at: datetime
+    modified_at: datetime
+
+
+class A2ARegistryAgentListResponse(BaseModel):
+    """Paginated list response for A2A registry agents."""
+
+    agents: List[A2ARegistryAgentResponse] = []
+    total: int = 0
+    page: int = 1
+    page_size: int = 50
+
+
+class A2ARegistrySyncResponse(BaseModel):
+    """Response schema for A2A registry sync operation."""
+
+    status: str
+    duration_seconds: float
+    fetched: int = 0
+    upserted: int = 0
+    deleted: int = 0

--- a/budconnect/a2a_registry/services.py
+++ b/budconnect/a2a_registry/services.py
@@ -143,9 +143,8 @@ class A2ARegistryService:
                     }
                     async with session.get(A2A_REGISTRY_URL, params=params) as resp:
                         if resp.status != 200:
-                            logger.error("A2A registry returned status %d", resp.status)
                             cls._record_failure()
-                            return all_agents
+                            raise RuntimeError(f"A2A registry returned status {resp.status}")
 
                         data = await resp.json()
                         agents = data.get("agents", [])
@@ -165,7 +164,7 @@ class A2ARegistryService:
         except Exception as e:
             cls._record_failure()
             logger.error("Failed to fetch from A2A registry: %s", e)
-            return all_agents
+            raise
 
     @staticmethod
     async def sync() -> Dict[str, int]:
@@ -193,12 +192,14 @@ class A2ARegistryService:
                     upserted += 1
                 except Exception as e:
                     logger.warning("Failed to upsert agent %s: %s", agent_data.get("base_url", "?"), e)
+            session.commit()
 
         deleted = 0
         if current_base_urls:
             with crud as crud_ctx:
                 session = crud_ctx.get_session()
                 deleted = crud.delete_absent(current_base_urls, session=session)
+                session.commit()
 
         summary = {"fetched": len(agents), "upserted": upserted, "deleted": deleted}
         logger.info("A2A registry sync complete: %s", summary)

--- a/budconnect/a2a_registry/services.py
+++ b/budconnect/a2a_registry/services.py
@@ -16,7 +16,6 @@
 
 """Service layer for A2A registry agent sync and retrieval."""
 
-import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -25,6 +24,7 @@ from budmicroframe.commons import logging
 
 from .crud import A2ARegistryAgentCRUD
 from .schemas import A2ARegistryAgentCreate, A2ARegistryAgentListResponse, A2ARegistryAgentResponse
+
 
 logger = logging.get_logger(__name__)
 

--- a/budconnect/a2a_registry/services.py
+++ b/budconnect/a2a_registry/services.py
@@ -1,0 +1,233 @@
+#  -----------------------------------------------------------------------------
+#  Copyright (c) 2024 Bud Ecosystem Inc.
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  -----------------------------------------------------------------------------
+
+"""Service layer for A2A registry agent sync and retrieval."""
+
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+from budmicroframe.commons import logging
+
+from .crud import A2ARegistryAgentCRUD
+from .schemas import A2ARegistryAgentCreate, A2ARegistryAgentListResponse, A2ARegistryAgentResponse
+
+logger = logging.get_logger(__name__)
+
+A2A_REGISTRY_URL = "https://a2aregistry.org/api/agents"
+FETCH_LIMIT = 50
+FETCH_TIMEOUT_SECONDS = 30
+MAX_PAGES = 50  # Safety cap: 50 pages × 50 = 2500 agents max
+CIRCUIT_BREAKER_THRESHOLD = 3
+CIRCUIT_BREAKER_COOLDOWN_SECONDS = 3600  # 1 hour
+
+
+class A2ARegistryService:
+    """Service for fetching A2A agents from a2aregistry.org and managing local storage."""
+
+    # Circuit breaker state (module-level, shared across instances)
+    _consecutive_failures: int = 0
+    _circuit_open_until: Optional[datetime] = None
+
+    @staticmethod
+    def _map_registry_agent(raw: Dict[str, Any]) -> Dict[str, Any]:
+        """Map a camelCase registry agent to snake_case DB fields.
+
+        Args:
+            raw: Raw agent dict from registry API response.
+
+        Returns:
+            Dict with snake_case keys matching A2ARegistryAgentCreate fields.
+        """
+        return {
+            "registry_id": str(raw.get("id", "")),
+            "base_url": raw.get("url", ""),
+            "name": raw.get("name", ""),
+            "description": raw.get("description"),
+            "author": raw.get("author"),
+            "version": raw.get("version"),
+            "protocol_version": raw.get("protocolVersion"),
+            "provider": raw.get("provider"),
+            "skills": raw.get("skills"),
+            "capabilities": raw.get("capabilities"),
+            "security_schemes": raw.get("securitySchemes"),
+            "security": raw.get("security"),
+            "icon_url": raw.get("iconUrl"),
+            "default_input_modes": raw.get("defaultInputModes"),
+            "default_output_modes": raw.get("defaultOutputModes"),
+            "documentation_url": raw.get("documentationUrl"),
+            "conformance": raw.get("conformance"),
+            "is_healthy": raw.get("is_healthy"),
+            "uptime_percentage": raw.get("uptime_percentage"),
+            "avg_response_time_ms": raw.get("avg_response_time_ms"),
+            "last_health_check": raw.get("last_health_check"),
+            "supports_authenticated_extended_card": raw.get("supportsAuthenticatedExtendedCard"),
+            "maintainer_notes": raw.get("maintainer_notes"),
+            "homepage": raw.get("homepage"),
+            "repository": raw.get("repository"),
+            "license": raw.get("license"),
+        }
+
+    @classmethod
+    def _is_circuit_open(cls) -> bool:
+        """Check if circuit breaker is open (should skip fetching)."""
+        if cls._circuit_open_until is None:
+            return False
+        if datetime.now(timezone.utc) >= cls._circuit_open_until:
+            cls._circuit_open_until = None
+            cls._consecutive_failures = 0
+            logger.info("A2A registry circuit breaker reset")
+            return False
+        return True
+
+    @classmethod
+    def _record_failure(cls) -> None:
+        """Record a fetch failure and potentially open circuit breaker."""
+        cls._consecutive_failures += 1
+        if cls._consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD:
+            from datetime import timedelta
+
+            cls._circuit_open_until = datetime.now(timezone.utc) + timedelta(seconds=CIRCUIT_BREAKER_COOLDOWN_SECONDS)
+            logger.warning(
+                "A2A registry circuit breaker OPEN after %d failures, cooling down for %ds",
+                cls._consecutive_failures,
+                CIRCUIT_BREAKER_COOLDOWN_SECONDS,
+            )
+
+    @classmethod
+    def _record_success(cls) -> None:
+        """Record a successful fetch and reset circuit breaker."""
+        cls._consecutive_failures = 0
+        cls._circuit_open_until = None
+
+    @classmethod
+    async def fetch_from_registry(cls) -> List[Dict[str, Any]]:
+        """Fetch standard, healthy A2A agents from a2aregistry.org.
+
+        Paginates with limit=50 + offset. Stops when len(agents) < limit.
+        Applies circuit breaker: skips after 3 consecutive failures for 1 hour.
+
+        Returns:
+            List of snake_case agent dicts ready for A2ARegistryAgentCreate.
+        """
+        if cls._is_circuit_open():
+            logger.warning("A2A registry circuit breaker is open, skipping fetch")
+            return []
+
+        all_agents: List[Dict[str, Any]] = []
+        timeout = aiohttp.ClientTimeout(total=FETCH_TIMEOUT_SECONDS)
+
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                for page in range(MAX_PAGES):
+                    offset = page * FETCH_LIMIT
+                    params = {
+                        "conformance": "standard",
+                        "healthy": "true",
+                        "limit": str(FETCH_LIMIT),
+                        "offset": str(offset),
+                    }
+                    async with session.get(A2A_REGISTRY_URL, params=params) as resp:
+                        if resp.status != 200:
+                            logger.error("A2A registry returned status %d", resp.status)
+                            cls._record_failure()
+                            return all_agents
+
+                        data = await resp.json()
+                        agents = data.get("agents", [])
+
+                        for raw_agent in agents:
+                            mapped = cls._map_registry_agent(raw_agent)
+                            if mapped["base_url"]:
+                                all_agents.append(mapped)
+
+                        if len(agents) < FETCH_LIMIT:
+                            break
+
+            cls._record_success()
+            logger.info("Fetched %d standard A2A agents from registry", len(all_agents))
+            return all_agents
+
+        except Exception as e:
+            cls._record_failure()
+            logger.error("Failed to fetch from A2A registry: %s", e)
+            return all_agents
+
+    @staticmethod
+    async def sync() -> Dict[str, int]:
+        """Full sync workflow: fetch → upsert → delete absent → return summary.
+
+        Returns:
+            Dict with keys: fetched, upserted, deleted.
+        """
+        agents = await A2ARegistryService.fetch_from_registry()
+        if not agents:
+            logger.warning("No A2A agents fetched from registry, skipping sync")
+            return {"fetched": 0, "upserted": 0, "deleted": 0}
+
+        crud = A2ARegistryAgentCRUD()
+        current_base_urls = set()
+        upserted = 0
+
+        with crud as crud_ctx:
+            session = crud_ctx.get_session()
+            for agent_data in agents:
+                try:
+                    create_schema = A2ARegistryAgentCreate(**agent_data)
+                    crud.upsert_by_base_url(create_schema.model_dump(), session=session)
+                    current_base_urls.add(agent_data["base_url"])
+                    upserted += 1
+                except Exception as e:
+                    logger.warning("Failed to upsert agent %s: %s", agent_data.get("base_url", "?"), e)
+
+        deleted = 0
+        if current_base_urls:
+            with crud as crud_ctx:
+                session = crud_ctx.get_session()
+                deleted = crud.delete_absent(current_base_urls, session=session)
+
+        summary = {"fetched": len(agents), "upserted": upserted, "deleted": deleted}
+        logger.info("A2A registry sync complete: %s", summary)
+        return summary
+
+    @staticmethod
+    def get_all_agents(
+        page: int = 1,
+        page_size: int = 50,
+    ) -> A2ARegistryAgentListResponse:
+        """Get paginated A2A registry agents from local DB.
+
+        Args:
+            page: Page number (1-indexed).
+            page_size: Results per page.
+
+        Returns:
+            A2ARegistryAgentListResponse with agents and pagination info.
+        """
+        crud = A2ARegistryAgentCRUD()
+        with crud as crud_ctx:
+            session = crud_ctx.get_session()
+            total, agents = crud.fetch_many(page=page, page_size=page_size, session=session)
+
+        agent_responses = [A2ARegistryAgentResponse.model_validate(agent) for agent in agents]
+
+        return A2ARegistryAgentListResponse(
+            agents=agent_responses,
+            total=total,
+            page=page,
+            page_size=page_size,
+        )

--- a/budconnect/main.py
+++ b/budconnect/main.py
@@ -33,6 +33,7 @@ from .eval.routes import eval_router
 from .guardrails.routes import guardrail_router
 from .license.routes import license_router
 from .model.routes import model_router
+from .a2a_registry.routes import a2a_registry_router
 from .provider.routes import provider_router
 from .seeders import seeders
 
@@ -101,3 +102,4 @@ app.include_router(license_router)
 app.include_router(model_router)
 app.include_router(guardrail_router)
 app.include_router(provider_router)
+app.include_router(a2a_registry_router)

--- a/budconnect/main.py
+++ b/budconnect/main.py
@@ -25,6 +25,7 @@ from budmicroframe.shared.dapr_workflow import DaprWorkflow
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .a2a_registry.routes import a2a_registry_router
 from .auth.routes import auth_router
 from .commons.config import app_settings, secrets_settings
 from .commons.exceptions import SeederException
@@ -33,7 +34,6 @@ from .eval.routes import eval_router
 from .guardrails.routes import guardrail_router
 from .license.routes import license_router
 from .model.routes import model_router
-from .a2a_registry.routes import a2a_registry_router
 from .provider.routes import provider_router
 from .seeders import seeders
 

--- a/budconnect/seeders/__init__.py
+++ b/budconnect/seeders/__init__.py
@@ -1,3 +1,4 @@
+from .a2a_registry import A2ARegistrySeeder
 from .engine import EngineSeeder
 from .guardrails import GuardrailsSeeder
 from .license import LicenseSeeder
@@ -18,4 +19,5 @@ seeders = {
     "model_details": ModelDetailsSeeder,  # This should run after litellm and tensorzero
     "guardrails": GuardrailsSeeder,  # This should run after tensorzero to ensure providers exist
     "model_architecture": ModelArchitectureSeeder,
+    "a2a_registry": A2ARegistrySeeder,  # Fetches A2A agents from a2aregistry.org
 }

--- a/budconnect/seeders/a2a_registry.py
+++ b/budconnect/seeders/a2a_registry.py
@@ -5,6 +5,7 @@ import logging
 from ..a2a_registry.services import A2ARegistryService
 from .base import BaseSeeder
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/budconnect/seeders/a2a_registry.py
+++ b/budconnect/seeders/a2a_registry.py
@@ -1,0 +1,27 @@
+"""A2A Registry seeder — fetches standard agents from a2aregistry.org on startup."""
+
+import logging
+
+from ..a2a_registry.services import A2ARegistryService
+from .base import BaseSeeder
+
+logger = logging.getLogger(__name__)
+
+
+class A2ARegistrySeeder(BaseSeeder):
+    """Seeds the database with A2A agents from a2aregistry.org."""
+
+    async def seed(self) -> None:
+        """Seed the database with A2A registry agents."""
+        logger.info("Starting A2A registry seeder...")
+        try:
+            summary = await A2ARegistryService.sync()
+            logger.info(
+                "A2A registry seeder completed: fetched=%d, upserted=%d, deleted=%d",
+                summary.get("fetched", 0),
+                summary.get("upserted", 0),
+                summary.get("deleted", 0),
+            )
+        except Exception as e:
+            logger.exception("Failed to seed A2A registry: %s", e)
+            raise

--- a/deploy/helm/templates/dapr-components.yaml
+++ b/deploy/helm/templates/dapr-components.yaml
@@ -88,6 +88,25 @@ scopes:
   - {{ .Values.name }}
 
 ---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: cron-a2a-registry-sync
+  namespace: {{ .Values.namespace }}
+spec:
+  type: bindings.cron
+  version: v1
+  metadata:
+    - name: schedule
+      value: "@every 12h"
+    - name: direction
+      value: "input"
+    - name: route
+      value: "/a2a-registry/cron-sync"
+scopes:
+  - {{ .Values.name }}
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
## Summary
- Adds a new `a2a_registry` module that fetches standard, healthy A2A agents from [a2aregistry.org](https://a2aregistry.org) and stores them locally for discovery by budapp
- Periodically syncs the catalog via a Dapr cron binding (every 12h) and seeds on startup
- Includes circuit breaker (3 consecutive failures → 1h cooldown) and pagination support (up to 2500 agents)

## What's included
- **Database:** `a2a_registry_agent` table with Alembic migration — stores agent metadata (skills, capabilities, health status, provider info, etc.) with `base_url` as unique dedup key
- **CRUD:** Upsert-by-base-url, paginated fetch, and delete-absent operations with caller-controlled transaction boundaries
- **Service layer:** Async fetch from registry API (aiohttp), full sync workflow (fetch → upsert → delete stale), and paginated local retrieval
- **API endpoints:**
  - `GET /a2a-registry/agents` — paginated agent listing
  - `POST /a2a-registry/cron-sync` — Dapr cron trigger with asyncio.Lock to prevent overlapping runs
- **Dapr component:** `cron-a2a-registry-sync` binding (dev + Helm)
- **Seeder:** `A2ARegistrySeeder` for initial population on startup

## Test plan
- [ ] Run Alembic migration and verify `a2a_registry_agent` table is created
- [ ] Start the app and verify the seeder fetches agents from a2aregistry.org
- [ ] Call `GET /a2a-registry/agents?page=1&page_size=10` and verify paginated response
- [ ] Trigger `POST /a2a-registry/cron-sync` and verify upsert/delete counts in response
- [ ] Verify circuit breaker activates after 3 consecutive fetch failures