### PR TITLE
fix: add model capability to huggingface provider

### DIFF
--- a/budconnect/seeders/data/tensorzero/tensorzero_providers.json
+++ b/budconnect/seeders/data/tensorzero/tensorzero_providers.json
@@ -479,6 +479,7 @@
             }
         ],
         "capabilities": [
+            "model",
             "local"
         ]
     },


### PR DESCRIPTION
## Summary

Add `"model"` to the `capabilities` array for the `huggingface` provider in `tensorzero_providers.json`, alongside the existing `"local"` entry.

```diff
"huggingface": {
    ...
    "capabilities": [
+       "model",
        "local"
    ]
}
```

## Why this change

`GET /model/get-compatible-models?engine={engine}` filters the provider list to entries whose `capabilities` contains `MODEL` (see `budconnect/model/services.py:197` → `ProviderCRUD.get_compatible_providers_with_capability(version_id, ProviderCapabilityEnum.MODEL, ...)`, which applies `func.array_to_string(Provider.capabilities, ",").contains(capability.name)` in `budconnect/model/crud.py:284`).

Until now, `huggingface` carried `capabilities: ["local"]` only, so the MODEL-capability filter excluded it from the response — even though the provider is seeded as one of the hardcoded predefined providers (`budconnect/seeders/tensorzero.py:698-720`) and is correctly linked to the tensorzero engine_version via `engine_version_provider`.

## Downstream impact (what this unblocks)

bud-runtime's `budapp` service drives its local-model onboarding workflow through a provider row keyed by `type='huggingface'` in budapp's own `provider` table. That row is populated by budapp's `CloudModelSyncScheduler` (`bud-runtime/services/budapp/budapp/model_ops/scheduler.py:42-119`) which calls budconnect's `/model/get-compatible-models?engine={CLOUD_MODEL_SEEDER_ENGINE}&limit=5&page=N` on a Dapr-scheduled cycle, upserts every provider returned, and soft-deletes any that aren't.

Because huggingface was missing from that response, no row ever landed in budapp, and `POST /models/local-model-workflow` with `provider_type=hugging_face` failed with:

```
{"object":"error","code":400,"message":"Provider not found","type":"BadRequesterror","param":null}
```

…raised at `budapp/model_ops/services.py:985-989` where the workflow looks up the provider via `retrieve_by_fields(ProviderModel, {"type": "huggingface"})`.

With this change, the next `cloud_model_sync` run after budconnect re-seeds will upsert the huggingface row into budapp's `provider` table and the endpoint stops 400-ing.

## Why `huggingface` belongs in MODEL too

`openai` already carries both `["model", "moderation"]` in the same JSON (`tensorzero_providers.json:336`), so multi-capability providers are an established pattern — they show up in both the MODEL-filtered sync (cloud_model_sync) and the MODERATION-filtered sync (guardrail_sync). Adding `"model"` to huggingface is the same shape.

`huggingface`-as-MODEL is conceptually a model-source provider: budapp's flow treats Hugging Face as a backend it can pull weights from. The `["local"]` capability stays because the provider is also consumed by budapp's local-model code path. Both consumers now see it.

## Verification

After this lands and budconnect re-seeds:

```bash
curl -sS 'https://budconnect.bud.studio/model/get-compatible-models?limit=20&engine=tensorzero&page=1' \
  | jq '[.items[] | select(.provider_type == "huggingface")] | length'
# expected: 1 (currently: 0)
```

Then in any cluster running budapp pointed at this budconnect, the next `cloud_model_sync` cycle (or a manual workflow trigger) will land a `huggingface` row in budapp's `provider` table; subsequent `POST /models/local-model-workflow` calls with `provider_type=hugging_face` will succeed.

## Out of scope

- `litellm_providers.json`: not touched. Apply the same diff there if/when a deployment with `CLOUD_MODEL_SEEDER_ENGINE=litellm` needs the same fix.
- Alternative shape: a new `LOCAL`-capability endpoint on budconnect (mirroring the existing MODERATION and MODEL endpoints) would let the `local` capability category be consumed without piggybacking on MODEL. Bigger surface; deferred until more than one local-only provider exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
