### PR TITLE
feat(guardrails): seed agent-governance policy packs via `agentmesh_policy` scanner type

### DIFF
--- a/alembic/versions/h3i4j5k6l7m8_add_agentmesh_policy_scanner_type.py
+++ b/alembic/versions/h3i4j5k6l7m8_add_agentmesh_policy_scanner_type.py
@@ -24,7 +24,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # Add the agentmesh_policy value to scanner_type_enum.
-    op.execute("ALTER TYPE scanner_type_enum ADD VALUE IF NOT EXISTS 'agentmesh_policy'")
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block on older
+    # PostgreSQL versions (and the value can't be used in the same transaction
+    # even on 12+), so run it in an autocommit block outside Alembic's transaction.
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE scanner_type_enum ADD VALUE IF NOT EXISTS 'agentmesh_policy'")
 
 
 def downgrade() -> None:

--- a/alembic/versions/h3i4j5k6l7m8_add_agentmesh_policy_scanner_type.py
+++ b/alembic/versions/h3i4j5k6l7m8_add_agentmesh_policy_scanner_type.py
@@ -1,0 +1,34 @@
+"""add agentmesh_policy scanner type
+
+Revision ID: h3i4j5k6l7m8
+Revises: h4i5j6k7l8m9
+Create Date: 2026-06-09 00:00:00.000000
+
+Adds the ``agentmesh_policy`` value to ``scanner_type_enum`` so agent-governance
+policy rules (bud-sentinel's agentmesh engine) seed with a real scanner_type
+instead of NULL. These rules carry a governance policy body rather than a
+scanner model, but the catalog advertises them under scanner_type like any
+other rule.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'h3i4j5k6l7m8'
+down_revision: Union[str, None] = 'h4i5j6k7l8m9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add the agentmesh_policy value to scanner_type_enum.
+    op.execute("ALTER TYPE scanner_type_enum ADD VALUE IF NOT EXISTS 'agentmesh_policy'")
+
+
+def downgrade() -> None:
+    # Note: PostgreSQL doesn't support removing enum values directly
+    # You would need to recreate the type and update all columns using it
+    # This is a complex operation and typically not done in production
+    pass

--- a/budconnect/commons/constants.py
+++ b/budconnect/commons/constants.py
@@ -133,9 +133,12 @@ class ScannerTypeEnum(str, Enum):
         LLM: LLM-based policy scanner.
         PATTERN: Pattern-based detection (regex, keywords).
         STATIC_CLASSIFIER: Static/rule-based classifier.
+        AGENTMESH_POLICY: Agent-governance policy (bud-sentinel agentmesh engine);
+            a model-less rule whose body is a governance policy, not a scanner model.
     """
 
     CLASSIFIER = "classifier"
     LLM = "llm"
     PATTERN = "pattern"
     STATIC_CLASSIFIER = "static_classifier"
+    AGENTMESH_POLICY = "agentmesh_policy"

--- a/budconnect/seeders/data/guardrails.json
+++ b/budconnect/seeders/data/guardrails.json
@@ -65,6 +65,102 @@
                 ]
             },
             {
+                "id": "governance.content_safety",
+                "title": "Content Safety",
+                "description": "Detector-based governance pack: blocks illegal/prohibited content and routes harmful content (toxicity, violence, self-harm) to human review. The policy body lives on the rule (catalog/rules/governance/content_safety.yaml).",
+                "icon": null,
+                "total_scanners": 1,
+                "total_rules": 1,
+                "rules": [
+                    {
+                        "id": "governance.content_safety.policy",
+                        "title": "Content Safety",
+                        "description": "Blocks illegal/prohibited content and routes harmful content (toxicity, violence, self-harm) to human review. Compliance: EU AI Act Art.5 (prohibited practices) / Art.14 (human oversight); NIST AI RMF MAP-5; OWASP LLM (output-handling).",
+                        "examples": [],
+                        "scanner": "agentmesh_policy",
+                        "modalities": [
+                            "text"
+                        ],
+                        "guard_types": [
+                            "input",
+                            "output"
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "governance.prompt_injection",
+                "title": "Prompt-Injection Defense",
+                "description": "Detector-based governance pack: blocks prompt-injection / jailbreak attempts on agent input using the BlazeEmb jailbreak classifier. The policy body lives on the rule (catalog/rules/governance/prompt_injection.yaml).",
+                "icon": null,
+                "total_scanners": 1,
+                "total_rules": 1,
+                "rules": [
+                    {
+                        "id": "governance.prompt_injection.policy",
+                        "title": "Prompt-Injection Defense",
+                        "description": "Blocks prompt-injection / jailbreak attempts on agent input. Compliance: OWASP LLM01 (Prompt Injection); OWASP ASI-01 (Agent Goal Hijack); EU AI Act Art.13/15(4); NIST AI RMF MAP-4; SOC2 CC6.8.",
+                        "examples": [],
+                        "scanner": "agentmesh_policy",
+                        "modalities": [
+                            "text"
+                        ],
+                        "guard_types": [
+                            "input",
+                            "output"
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "governance.regulated_advice",
+                "title": "Regulated Advice Oversight",
+                "description": "Detector-based governance pack: routes regulated-domain advice (medical, legal, financial) to human review/disclaimer using the BlazeEmb regulated-advice classifier. The policy body lives on the rule (catalog/rules/governance/regulated_advice.yaml).",
+                "icon": null,
+                "total_scanners": 1,
+                "total_rules": 1,
+                "rules": [
+                    {
+                        "id": "governance.regulated_advice.policy",
+                        "title": "Regulated Advice Oversight",
+                        "description": "Routes regulated-domain advice (medical, legal, financial) in responses to human review/disclaimer. Compliance: EU AI Act Art.26 (deployer obligations); NIST AI RMF MANAGE-3.",
+                        "examples": [],
+                        "scanner": "agentmesh_policy",
+                        "modalities": [
+                            "text"
+                        ],
+                        "guard_types": [
+                            "input",
+                            "output"
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "governance.sensitive_data",
+                "title": "Sensitive Data Protection",
+                "description": "Detector-based governance pack: redacts personal data (PII/PHI) and secrets/credentials in agent request and response content. The policy body lives on the rule (catalog/rules/governance/sensitive_data.yaml).",
+                "icon": null,
+                "total_scanners": 1,
+                "total_rules": 1,
+                "rules": [
+                    {
+                        "id": "governance.sensitive_data.policy",
+                        "title": "Sensitive Data Protection",
+                        "description": "Redacts PII/PHI and secrets/credentials in request and response content. Compliance: OWASP LLM06 (Sensitive Information Disclosure); OWASP ASI-03/ASI-06; EU AI Act Art.5/15(4)/26(4); GDPR Art.5/32; HIPAA; PCI-DSS; SOC2 C1.1/P6; NIST AI RMF MAP-5/GOVERN-4.",
+                        "examples": [],
+                        "scanner": "agentmesh_policy",
+                        "modalities": [
+                            "text"
+                        ],
+                        "guard_types": [
+                            "input",
+                            "output"
+                        ]
+                    }
+                ]
+            },
+            {
                 "id": "gpt_safeguard_asylum_seeker_assistance",
                 "title": "Asylum Seeker Assistance Quality",
                 "description": "Evaluates AI responses for asylum seeker support quality across actionability, factuality, safety, tone, non-discrimination, and access. Classifies severity from moderate to critical.",


### PR DESCRIPTION
## Summary

bud-sentinel's agent-governance **policy packs** (`governance.*`) are catalog rules
whose `scanner` is `agentmesh_policy` — a model-less rule whose body is a governance
policy rather than a backing scanner model. They were already exported by
bud-sentinel's `scripts/export_catalog.py`, but budconnect could not represent them:
`ScannerTypeEnum` had no `agentmesh_policy` member, so the guardrails seeder logged
`Unknown scanner_type` and stored `scanner_type = NULL`. With a NULL scanner type the
packs are invisible to downstream filters (budapp's governance filter keys on
`scanner_type = agentmesh_policy`).

This PR teaches budconnect the `agentmesh_policy` scanner type and adds the four
governance packs to the catalog seed, so they seed and surface through the guardrail
catalog APIs like any other rule. Consistent with how gpt-oss/`gpt_safeguard` rules
are handled, the catalog carries **metadata only** — the governance policy body stays
sentinel-side and reaches budapp via REST authoring/sync, not the seed.

## Changes

| File | Change |
|---|---|
| `budconnect/commons/constants.py` | Add `ScannerTypeEnum.AGENTMESH_POLICY = "agentmesh_policy"` (+ docstring) |
| `alembic/versions/h3i4j5k6l7m8_add_agentmesh_policy_scanner_type.py` | `ALTER TYPE scanner_type_enum ADD VALUE IF NOT EXISTS 'agentmesh_policy'` (idempotent; downgrade is a documented no-op, since PostgreSQL cannot drop an enum value) |
| `budconnect/seeders/data/guardrails.json` | Insert the 4 `governance.*` probes — `content_safety`, `prompt_injection`, `regulated_advice`, `sensitive_data` |

`3 files changed, 133 insertions(+)`

### Notes for reviewers

- **Migration parent:** `down_revision = h4i5j6k7l8m9` (the post-merge head). The
  change is purely additive (`ADD VALUE`), so ordering relative to sibling migrations
  is irrelevant; it was re-parented onto the new tip to keep a single linear head.
- **Seed edit is a pure insertion.** The 4 governance probes were inserted textually
  (sorted before `gpt_safeguard_*`); the existing 38 bud_sentinel probes are
  byte-identical. A whole-file regenerate was deliberately avoided — the committed
  `guardrails.json` is mixed-encoding (raw `ö` alongside escaped `°`), so no
  single `json.dump(ensure_ascii=...)` reproduces it and a regenerate would churn
  unrelated PII/secrets description text.
- **No policy body in the catalog**, by design — `governance.*` rules carry
  `scanner_type=agentmesh_policy` and `model_id=None`; the policy body is authored/synced
  separately.

## Test plan

Verified live against the dev stack (`./deploy/start_dev.sh -d`, app on `:9088`,
seeders enabled by default):

- [x] `alembic upgrade head` applies cleanly — log: `Running upgrade h4i5j6k7l8m9 -> h3i4j5k6l7m8`; `alembic_version = h3i4j5k6l7m8`.
- [x] `pg_enum` for `scanner_type_enum` includes `agentmesh_policy`.
- [x] Guardrails seeder: `bud_sentinel — Probes upserted: 42, Rules upserted: 266`, **zero `Unknown scanner_type` warnings** (the enum-column INSERT of `agentmesh_policy` succeeds).
- [x] `GET /guardrail/get-compatible-guardrails?engine=tensorzero` → bud_sentinel returns 42 probes incl. all 4 governance packs, each `scanner_types=['agentmesh_policy']`.
- [x] `GET /guardrail/probes/{id}/rules` → `agentmesh_policy/governance.content_safety.policy`, `scanner_type=agentmesh_policy`, `guard_types=['input','output']`, `model_id=None`.

## Rollout

Requires `alembic upgrade head` on deploy (adds the enum value) before the updated
seed runs. No data backfill needed — existing rows are unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BudEcosystem/codesmith/bud-connect/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783588122&installation_id=133469016&pr_number=29&repository=BudEcosystem%2Fbud-connect&return_to=https%3A%2F%2Fgithub.com%2FBudEcosystem%2Fbud-connect%2Fpull%2F29&signature=8caa0299e5bc6a01ce0bb472fc951650d003a21604b8d309e5da383f69686ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->