### PR TITLE
feat(engine): bump latentbud CPU engine to 0.3.0 for LFM2 embedding

### DIFF
--- a/budconnect/seeders/data/engines.json
+++ b/budconnect/seeders/data/engines.json
@@ -1347,9 +1347,9 @@
                 ]
             },
             {
-                "version": "0.2.0",
+                "version": "0.3.0",
                 "device_architecture": "CPU",
-                "container_image": "budstudio/latentbud-cpu:0.2.0",
+                "container_image": "registry.bud.studio/runtime/latentbud-cpu:0.3.0",
                 "compatibilities": [
                     {
                         "architecture": [],


### PR DESCRIPTION
## Summary
The latentbud **CPU** engine `0.2.0` (`budstudio/latentbud-cpu:0.2.0`) cannot serve **LiquidAI LFM2.5 embedding** models (architecture `Lfm2BidirectionalModel`). It crashes on startup with two independent failures:

1. **Stale ML libs** — bundled `transformers` (Jan-2025 git pin) + `sentence-transformers` 3.4.1 don't recognize the `lfm2` architecture. The model needs `transformers>=4.56.2` and was serialized with `sentence-transformers 5.1.1`.
2. **BudTikTok overflow** — the model's `tokenizer_config.json` sets `model_max_length` to HF's ~1e30 "unset" sentinel, which overflows BudTikTok's Rust int conversion (`OverflowError: int too big to convert`).

Both are fixed in the new image **`registry.bud.studio/runtime/latentbud-cpu:0.3.0`** (lib bump + `model_max_length` clamp), validated end-to-end serving `LiquidAI/LFM2.5-Embedding-350M` on CPU.

## Change
Point the latentbud **CPU** `EngineVersion` at `0.3.0` / the Harbor image.

```
CPU  0.2.0  budstudio/latentbud-cpu:0.2.0
       →  0.3.0  registry.bud.studio/runtime/latentbud-cpu:0.3.0
```

## How it takes effect
`get-compatible-engines` returns the **latest version per engine+device** (ranked by `created_at DESC`), so the additive `EngineSeeder` inserts `0.3.0` and it supersedes `0.2.0` for latentbud/CPU automatically. budsim then resolves the new image at simulation time.

## Deploy notes
- **Requires `RUN_SEEDERS_ON_STARTUP=true`** on the budconnect deployment so the `EngineSeeder` runs and inserts the new version.
- The seeder is additive — it does **not** edit `0.2.0` in place; `0.2.0` remains in the DB but loses on recency.
- **CUDA is intentionally left at `0.2.0`.** No `0.3.0` CUDA image has been built yet; it has the same two bugs and would need a separate rebuild before LFM2 GPU deploys work.

## Testing
- Built `latentbud-cpu:0.3.0` from LatentBud (transformers 4.56.2, sentence-transformers 5.1.1, BudTikTok clamp), pushed to `registry.bud.studio/runtime/latentbud-cpu:0.3.0`.
- Ran the image serving `LiquidAI/LFM2.5-Embedding-350M` on CPU: `/health` 200, `/embeddings` returns 1024-dim vectors, cos(query, relevant-doc)=0.69 vs cos(query, unrelated)=0.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BudEcosystem/codesmith/bud-connect/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785314004&installation_id=133469016&pr_number=31&repository=BudEcosystem%2Fbud-connect&return_to=https%3A%2F%2Fgithub.com%2FBudEcosystem%2Fbud-connect%2Fpull%2F31&signature=65484d3ceeceb411a4d5618e06f86da9cad99e875bc2896f5f9cd0336095fa76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->