### PR TITLE
chore(engine): bump latentbud images to 0.3.1

### DIFF
--- a/budconnect/seeders/data/engines.json
+++ b/budconnect/seeders/data/engines.json
@@ -1326,9 +1326,9 @@
         "name": "latentbud",
         "versions": [
             {
-                "version": "0.2.0",
+                "version": "0.3.1",
                 "device_architecture": "CUDA",
-                "container_image": "budstudio/latentbud-cuda:0.2.0",
+                "container_image": "registry.bud.studio/runtime/latentbud-cuda:0.3.1",
                 "compatibilities": [
                     {
                         "architecture": [],
@@ -1341,9 +1341,9 @@
                 ]
             },
             {
-                "version": "0.3.0",
+                "version": "0.3.1",
                 "device_architecture": "CPU",
-                "container_image": "registry.bud.studio/runtime/latentbud-cpu:0.3.0",
+                "container_image": "registry.bud.studio/runtime/latentbud-cpu:0.3.1",
                 "compatibilities": [
                     {
                         "architecture": [],


### PR DESCRIPTION
## What changed

Updated both `latentbud` engine builds in `budconnect/seeders/data/engines.json` to version **0.3.1**:

| Version | Device | Container image |
|---------|--------|-----------------|
| 0.3.1 | CUDA | `registry.bud.studio/runtime/latentbud-cuda:0.3.1` |
| 0.3.1 | CPU | `registry.bud.studio/runtime/latentbud-cpu:0.3.1` |

## Why

New 0.3.1 images are available for both device architectures.

## Notes for reviewers

- The CUDA image previously lived on Docker Hub (`budstudio/latentbud-cuda:0.2.0`) and has been moved to the `registry.bud.studio/runtime/` registry to match the CPU build.
- Both builds continue to support the `EMBEDDING` and `CLASSIFY` endpoints; only the version tags and CUDA registry path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BudEcosystem/codesmith/bud-connect/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786896652&installation_id=133469016&pr_number=33&repository=BudEcosystem%2Fbud-connect&return_to=https%3A%2F%2Fgithub.com%2FBudEcosystem%2Fbud-connect%2Fpull%2F33&signature=27744a7dd3c2dbbf2fb3518d9b5f3aa9ee6c34e3e5677c2ab6c8941e5b03db1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->